### PR TITLE
CI: Test for all branches, use setup-dlang@v1

### DIFF
--- a/.github/workflows/d.yml
+++ b/.github/workflows/d.yml
@@ -1,14 +1,6 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 name: D
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -17,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: dlang-community/setup-dlang@4c99aa991ce7d19dd3064de0a4f2f6b2f152e2d7
+    - uses: dlang-community/setup-dlang@v1
 
     - name: 'Build & Test'
       shell: cmd


### PR DESCRIPTION
The workflow was originally generated from a starter workflow, which requires workflow templates which are not sanctioned by Github (such as D's) to use a commit hash, pinning the version, while other workflows (Go, Rust, etc...) can use a branch (`v1`, `v2`, etc...), which is Github's recommended practice.

This commit changes the dependency from a hash to a branch, along with removing the comment that Github requires from non-partner action.

Finally, the condition to trigger this workflow are simplified, and extended to the accepted best practice for collaborative projects using the fork model.